### PR TITLE
Fix Displaying Spell Components

### DIFF
--- a/src/Pages/SpellDetailsPage.js
+++ b/src/Pages/SpellDetailsPage.js
@@ -43,7 +43,7 @@ function SpellDetailsPage() {
           <div className="detailRow">
             <strong>Components:</strong>{" "}
             <span>
-              {spellData.Components.map((component) => component + " ")}
+              {spellData.components.map((component) => component + " ")}
             </span>
           </div>
           <div className="detailRow">


### PR DESCRIPTION
While fixing import path structure, I broke displaying spell components on spell details. This is the fix for that. 